### PR TITLE
Permissions issues and undefined index for page_orientation

### DIFF
--- a/exports-and-reports.php
+++ b/exports-and-reports.php
@@ -1217,12 +1217,13 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 				}
 
 				$selectable_reports[ $report->id ] = array(
-					'name'            => $report->name,
-					'sql_query'       => $report->sql_query,
-					'sql_query_count' => $report->sql_query_count,
-					'default_none'    => $report->default_none,
-					'export'          => ( 0 === (int) $report->disable_export ? true : false ),
-					'field_data'      => $report->field_data,
+					'name'             => $report->name,
+					'sql_query'        => $report->sql_query,
+					'sql_query_count'  => $report->sql_query_count,
+					'default_none'     => $report->default_none,
+					'export'           => ( 0 === (int) $report->disable_export ? true : false ),
+					'field_data'       => $report->field_data,
+					'page_orientation' => $report->page_orientation,
 				);
 			}
 		}

--- a/exports-and-reports.php
+++ b/exports-and-reports.php
@@ -250,7 +250,7 @@ function exports_reports_menu() {
 	$init = false;
 
 	$sql = '
-		SELECT `id`, `name`
+		SELECT `id`, `role_access`, `name`
 		FROM `' . EXPORTS_REPORTS_TBL . 'groups`
 		WHERE `disabled` = 0
 		ORDER BY `weight`, `name`	
@@ -265,7 +265,6 @@ function exports_reports_menu() {
 				FROM `' . EXPORTS_REPORTS_TBL . 'reports`
 				WHERE `disabled` = 0 AND `group` = %d
 				ORDER BY `weight`, `name`
-				LIMIT 1	
 			';
 
 			$sql = $wpdb->prepare( $sql, array( $group->id ) );
@@ -288,7 +287,7 @@ function exports_reports_menu() {
 						break;
 					}
 
-					$roles = explode( ',', $report->role_access );
+					$roles = array_unique( array_merge( explode( ',', $group->role_access ), explode( ',', $report->role_access ) ) );
 
 					if ( empty( $roles ) ) {
 						continue;
@@ -306,7 +305,7 @@ function exports_reports_menu() {
 
 							add_submenu_page( $init, $group->name, $group->name, 'read', $menu_page, 'exports_reports_view' );
 
-							break;
+							break 2;
 						}
 					}
 				}
@@ -1096,7 +1095,7 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 		}
 
 		$sql = '
-			SELECT `id`
+			SELECT `id`, `role_access`
 			FROM `' . EXPORTS_REPORTS_TBL . 'groups`
 			WHERE `disabled` = 0 AND `id` = %d
 			ORDER BY `weight`, `name`
@@ -1110,11 +1109,13 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 		if ( empty( $group ) ) {
 			return false;
 		}
+		$group_roles = explode( ',', $group->role_access );
 	} else {
 		$group_id = 0;
+		$group_roles = [];
 
 		$sql = '
-			SELECT `id`
+			SELECT `id`, `role_access`
 			FROM `' . EXPORTS_REPORTS_TBL . 'groups`
 			WHERE `disabled` = 0
 			ORDER BY `weight`, `name`
@@ -1129,7 +1130,6 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 					FROM `' . EXPORTS_REPORTS_TBL . 'reports`
 					WHERE `disabled` = 0 AND `group` = %d
 					ORDER BY `weight`, `name`
-					LIMIT 1
 				';
 
 				$sql = $wpdb->prepare( $sql, array( $group->id ) );
@@ -1140,11 +1140,12 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 					foreach ( $reports as $report ) {
 						if ( $has_full_access || exports_reports_current_user_can_any( 'exports_reports_view' ) || exports_reports_current_user_can_any( 'exports_reports_view_group_' . $group->id ) || exports_reports_current_user_can_any( 'exports_reports_view_report_' . $report->id ) ) {
 							$group_id = $group->id;
+							$group_roles = explode( ',', $group->role_access );
 
 							break;
 						}
 
-						$roles = explode( ',', $report->role_access );
+						$roles = array_unique( array_merge( explode( ',', $group->role_access ), explode( ',', $report->role_access ) ) );
 
 						if ( empty( $roles ) ) {
 							continue;
@@ -1153,8 +1154,9 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 						foreach ( $roles as $role ) {
 							if ( exports_reports_has_role( $role ) ) {
 								$group_id = $group->id;
+								$group_roles = explode( ',', $group->role_access );
 
-								break;
+								break 2;
 							}
 						}
 					}
@@ -1170,7 +1172,7 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 	$sql = '
 		SELECT *
 		FROM `' . EXPORTS_REPORTS_TBL . 'reports`
-		WHERE `group` = %d
+		WHERE `disabled` = 0 AND `group` = %d
 		ORDER BY `weight`, `name`
 	';
 
@@ -1204,7 +1206,7 @@ function exports_reports_view( $group_id = false, $has_full_access = null ) {
 			continue;
 		}
 
-		$roles = explode( ',', $report->role_access );
+		$roles = array_unique( array_merge( $group_roles, explode( ',', $report->role_access ) ) );
 
 		if ( empty( $roles ) ) {
 			continue;


### PR DESCRIPTION
I found several cases with permissions issues based on the existing configuration.

Permissions defined in the Groups list were not being utilized or considered when evaluating the permissions for each report. Also, there were cases (due to LIMIT 1 in SQL queries) that only loaded a single report for access roles considerations.

I updated the code to consider Group permissions > Report permissions.

I also fixed a few other minor issues (`break 2` vs. `break`, and missing `disabled = 0`).
